### PR TITLE
removing docs-home layout

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,8 +2,14 @@
 layout: docs-content
 title:  "Guide to Processing Collections at the RAC"
 ---
-Welcome to the *Guide to Processing Collections at the Rockefeller Archive Center*, created by the RAC Processing Team. The Manual is divided into three sections:
+The *Guide to Processing Collections at the Rockefeller Archive Center* provides detailed documentation on the archival processing methods used at the RAC. It was written by the RAC Processing Team, and within the institution, it is commonly referred to as the processing manual.
+
+The Guide is divided into three sections:
 
 - [About](about) - the mission of the Processing Team and information about RAC processing methods.
 - [Planning](planning) - instructions on how to get started on a new processing project.
 - [Processing](processing) - provides step-by-step instructions for processing archival collections at the RAC.
+
+In drafting the guide, the RAC Processing Team focused primarily on creating local practices and procedures that implemented the guidelines and principles established in [Describing Archives: A Content Standard (DACS)](https://www2.archivists.org/standards/DACS). DACS is the official archival description standard of the [Society of American Archivists (SAA)](https://www2.archivists.org/), a national professional association for archivists. The RAC Processing Team consulted a number of SAA resources such as the SAA online glossary - [A Glossary of Archival and Records Terminology by Richard Pearce-Moses](https://www2.archivists.org/glossary) - when outlining its policies in the guide.
+
+The guide is available to the public under a [Creative Commons Zero (CC0)](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: docs-home
+layout: docs-content
 title:  "Guide to Processing Collections at the RAC"
 ---
 Welcome to the *Guide to Processing Collections at the Rockefeller Archive Center*, created by the RAC Processing Team. The Manual is divided into three sections:


### PR DESCRIPTION
the change from docs-home to docs-content doesn't appear to have messed up the formatting at all. it just added the breadcrumbs and the side-nav. docs-home could likely be removed completely from the docs-theme repo