### PR TITLE
Update title and remove tag and category configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Guide to Processing Collections at the Rockefeller Archive Center
+# Processing Manual
 
-The *Rockefeller Archive Center Guide to Processing Collections* provides detailed documentation on the archival processing strategies and methods used at the RAC. It was written by the RAC Processing Team in close collaboration with other members of the RAC archival staff.
+The Rockefeller Archive Center Processing Manual provides detailed documentation on the archival processing strategies and methods used at the RAC. It was written by the RAC Processing Team in close collaboration with other members of the RAC archival staff.
 
 ## Accessing the guide
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,8 @@
 public: true
 type: "docs"
-category: "arrangement and description"
-tags:
-  - "workflow"
-title: "Guide to Processing Collections"
+title: "Processing Manual"
 description: "A manual for arranging and describing archival collections."
 pages:
-  - ["Guide to Processing Collections", "index"]
+  - ["Processing Manual", "index"]
   - ["Planning", "planning"]
   - ["Processing", "processing"]

--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
 ---
 layout: docs
-title:  "Guide to Processing Collections"
+title:  "Processing Manual"
 ---
-The *Rockefeller Archive Center Guide to Processing Collections* provides detailed documentation on the archival processing strategies and methods used at the RAC. It was written by the RAC Processing Team in close collaboration with other members of the RAC archival staff. Within the institution, it is commonly referred to as the Processing Manual.
+The Rockefeller Archive Center Processing Manual provides detailed documentation on the archival processing strategies and methods used at the RAC. It was written by the RAC Processing Team in close collaboration with other members of the RAC archival staff.
 
 ## Mission
 

--- a/planning.md
+++ b/planning.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title:  "Guide to Processing Collections - Planning"
+title:  "Processing Manual - Planning"
 ---
 
 **_All processing activities at RAC must be approved by the Head of Processing._**

--- a/processing.md
+++ b/processing.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title:  "Guide to Processing Collections - Processing"
+title:  "Processing Manual - Processing"
 ---
 
 The processing phase of each assignment begins with contemplating five vital questions –  


### PR DESCRIPTION
Updates to support the https://github.com/RockefellerArchiveCenter/docs-build/pull/219.

Do not merge until docs-build PR #219 Style Library implementation is merged.